### PR TITLE
Add variable, because without it, column "Year" are still type:object

### DIFF
--- a/04.Data_Wrangling_2z5.ipynb
+++ b/04.Data_Wrangling_2z5.ipynb
@@ -459,7 +459,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "melted_demographics['Year'].astype('int64')\n",
+    "melted_demographics['Year'] = melted_demographics['Year'].astype('int64')\n",
     "melted_demographics"
    ]
   },


### PR DESCRIPTION
Change `melted_demographics['Year'].astype('int64')` into `melted_demographics['Year'] = melted_demographics['Year'].astype('int64')`

because before changes melted_demographics.dtypes get column "Year" type object, after changes, get type int64.